### PR TITLE
Use HashLocationStrategy

### DIFF
--- a/src/main/static/app/app.module.ts
+++ b/src/main/static/app/app.module.ts
@@ -1,5 +1,5 @@
-import
-{NgModule} from "@angular/core";
+import {NgModule} from "@angular/core";
+import {HashLocationStrategy, Location, LocationStrategy} from '@angular/common';
 import {BrowserModule} from "@angular/platform-browser";
 import {FormsModule} from "@angular/forms";
 import {HttpModule, JsonpModule } from "@angular/http";
@@ -61,7 +61,9 @@ import {ChartModule} from 'primeng/primeng';
         SpeakerService,
         SessionService,
         ScheduleService,
-        VoteService
+        VoteService,
+        Location,
+        {provide: LocationStrategy, useClass: HashLocationStrategy}
     ],
     bootstrap: [
         AppComponent

--- a/src/main/static/index.html
+++ b/src/main/static/index.html
@@ -16,7 +16,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <base href="/">
     <title>Microprofile Conference</title>
     <link rel="icon" href="assets/images/favicon.png">
 


### PR DESCRIPTION
Switching to use HashLocationStrategy (so pages within the app are linked as, for example, `#/sessions` rather than `/sessions`) has two benefits. Firstly, it means that we can remove the base href from index.html which means that it only needs a change to ingress to run the app on something other than /. Secondly, it means that the links actually work if you try to reload the page rather than getting a 404 back from Liberty.