### PR TITLE
Fixes to Web-App for Power PC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM websphere-liberty:webProfile7
 COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/server.xml
 RUN installUtility install --acceptLicense defaultServer
+#checks if the sample app is being built on power architecture, pulls a pre-built .war file if so due to missing modules on PPC
+RUN if (uname -a | grep -i "PPC\|power"); then wget https://github.com/WASdev/sample.microservicebuilder.web-app/releases/download/1.0/web-application-1.0.0-SNAPSHOT.war && mv web-application-1.0.0-SNAPSHOT.war target; fi
 COPY target/web-application-1.0.0-SNAPSHOT.war /opt/ibm/wlp/usr/servers/defaultServer/apps/web-app.war

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM websphere-liberty:webProfile7
 COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/server.xml
 RUN installUtility install --acceptLicense defaultServer
 #checks if the sample app is being built on power architecture, pulls a pre-built .war file if so due to missing modules on PPC
-RUN if (uname -a | grep -i "PPC\|power"); then wget https://github.com/WASdev/sample.microservicebuilder.web-app/releases/download/1.0/web-application-1.0.0-SNAPSHOT.war -o /opt/ibm/wlp/usr/servers/defaultServer/apps/web-application-1.0.0-SNAPSHOT.war ; fi
+RUN if (uname -a | grep -i "PPC\|power"); then wget https://github.com/WASdev/sample.microservicebuilder.web-app/releases/download/1.0/web-application-1.0.0-SNAPSHOT.war && mv /web-application-1.0.0-SNAPSHOT.war /opt/ibm/wlp/usr/servers/defaultServer/apps/web-application-1.0.0-SNAPSHOT.war; fi
 COPY target /opt/ibm/wlp/usr/servers/defaultServer/apps/
 RUN mv /opt/ibm/wlp/usr/servers/defaultServer/apps/web-application-1.0.0-SNAPSHOT.war /opt/ibm/wlp/usr/servers/defaultServer/apps/web-app.war

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM websphere-liberty:webProfile7
 COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/server.xml
 RUN installUtility install --acceptLicense defaultServer
 #checks if the sample app is being built on power architecture, pulls a pre-built .war file if so due to missing modules on PPC
-RUN if (uname -a | grep -i "PPC\|power"); then mkdir target && wget https://github.com/WASdev/sample.microservicebuilder.web-app/releases/download/1.0/web-application-1.0.0-SNAPSHOT.war && mv web-application-1.0.0-SNAPSHOT.war target; fi
-COPY target/web-application-1.0.0-SNAPSHOT.war /opt/ibm/wlp/usr/servers/defaultServer/apps/web-app.war
+RUN if (uname -a | grep -i "PPC\|power"); then wget https://github.com/WASdev/sample.microservicebuilder.web-app/releases/download/1.0/web-application-1.0.0-SNAPSHOT.war -o /opt/ibm/wlp/usr/servers/defaultServer/apps/web-application-1.0.0-SNAPSHOT.war ; fi
+COPY target /opt/ibm/wlp/usr/servers/defaultServer/apps/
+RUN mv /opt/ibm/wlp/usr/servers/defaultServer/apps/web-application-1.0.0-SNAPSHOT.war /opt/ibm/wlp/usr/servers/defaultServer/apps/web-app.war

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM websphere-liberty:webProfile7
 COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/server.xml
 RUN installUtility install --acceptLicense defaultServer
 #checks if the sample app is being built on power architecture, pulls a pre-built .war file if so due to missing modules on PPC
-RUN if (uname -a | grep -i "PPC\|power"); then wget https://github.com/WASdev/sample.microservicebuilder.web-app/releases/download/1.0/web-application-1.0.0-SNAPSHOT.war && mv web-application-1.0.0-SNAPSHOT.war target; fi
+RUN if (uname -a | grep -i "PPC\|power"); then mkdir target && wget https://github.com/WASdev/sample.microservicebuilder.web-app/releases/download/1.0/web-application-1.0.0-SNAPSHOT.war && mv web-application-1.0.0-SNAPSHOT.war target; fi
 COPY target/web-application-1.0.0-SNAPSHOT.war /opt/ibm/wlp/usr/servers/defaultServer/apps/web-app.war

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Microservice Builder Sample - Web front end
 
-See the [sample documentation](http://github.com/WASdev/sample.microservicebuilder.docs) for more information.
+See the [sample documentation](http://github.com/WASdev/sample.microservicebuilder.docs) for more information.     

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
     </build>
   </profile>
       <!--Power PC Archtecture devices will not build WAR file here, but it will be curled in at docker build. This intentionally does nothing-->
+
       <profile>
         <id>PowerPC</id>
         <activation>
@@ -159,6 +160,25 @@
           <plugins>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <version>1.7</version>
+              <executions>
+                <execution>
+                  <phase>generate-test-sources</phase>
+                  <configuration>
+                    <tasks>
+                      <echo message="Creating Target" />
+                      <mkdir dir="./target" />
+                    </tasks>
+                  </configuration>
+                  <goals>
+                    <goal>run</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-war-plugin</artifactId>
               <version>3.0.0</version>
               <configuration>
@@ -168,6 +188,8 @@
           </plugins>
         </build>
       </profile>
+
+
         <profile>
             <id>security</id>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,15 +16,20 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>sample.microservicebuilder</groupId>
     <version>1.0.0-SNAPSHOT</version>
     <artifactId>web-application</artifactId>
     <name>Conference :: Web</name>
     <packaging>war</packaging>
-
+    <profiles>
+      <profile>
+        <id>Linux_x86</id>
+        <activation>
+          <os>
+            <arch>!ppc64le</arch>
+          </os>
+        </activation>
     <dependencies>
       <dependency>
             <groupId>org.apache.tomee</groupId>
@@ -51,7 +56,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
           <plugin>
@@ -71,7 +75,6 @@
                 </images>
               </configuration>
             </plugin>
-
             <!--Deals with npm, bower and gulp-->
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -116,7 +119,6 @@
                     <workingDirectory>src/main/static</workingDirectory>
                 </configuration>
             </plugin>
-
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
@@ -131,7 +133,6 @@
                 </webResources>
             </configuration>
         </plugin>
-
         <plugin>
             <artifactId>maven-clean-plugin</artifactId>
             <version>3.0.0</version>
@@ -145,8 +146,28 @@
         </plugin>
         </plugins>
     </build>
-
-    <profiles>
+  </profile>
+      <!--Power PC Archtecture devices will not build WAR file here, but it will be curled in at docker build. This intentionally does nothing-->
+      <profile>
+        <id>PowerPC</id>
+        <activation>
+          <os>
+            <arch>ppc64le</arch>
+          </os>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-war-plugin</artifactId>
+              <version>3.0.0</version>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
         <profile>
             <id>security</id>
             <properties>
@@ -175,5 +196,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         </plugins>
     </build>
   </profile>
-      <!--Power PC Archtecture devices will not build WAR file here, but it will be curled in at docker build. This intentionally does nothing-->
+      <!--Power PC Architecture devices will not build a WAR file here: it will be curled in at docker build. The target/ directory must exist for the Dockerfile to work correctly. -->
 
       <profile>
         <id>PowerPC</id>


### PR DESCRIPTION
Fixes to web-app so that it can be built on Power PC. The fix includes skipping a maven build and pulling down a pre-built WAR file from github for the docker build so that web-app can run on the PPC architectures. 